### PR TITLE
Downgrade sqlcipher to 4.6.1

### DIFF
--- a/org.sqlitebrowser.sqlitebrowser.yml
+++ b/org.sqlitebrowser.sqlitebrowser.yml
@@ -18,14 +18,13 @@ cleanup:
   - '*.la'
 
 modules:
-  - tcl.json
   - name: sqlcipher
     buildsystem: autotools
     build-options:
       cflags: -DSQLITE_HAS_CODEC
       ldflags: -lcrypto
     config-opts:
-      - --enable-tempstore=yes
+      - --with-tempstore=yes
       - --enable-releasemode
       - --disable-static
       - --disable-tcl
@@ -33,6 +32,12 @@ modules:
       - type: git
         url: https://github.com/sqlcipher/sqlcipher.git
         tag: v4.6.1
+        commit: c5bd336ece77922433aaf6d6fe8cf203b0c299d5
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+          versions:
+            < : 4.7.0
 
   - name: sqlitebrowser
     buildsystem: cmake-ninja


### PR DESCRIPTION
Newer versions override libsqlite library from the runtime and aren't supported by linux ecosystem