### PR TITLE
Remove sqlcipher

### DIFF
--- a/org.sqlitebrowser.sqlitebrowser.yml
+++ b/org.sqlitebrowser.sqlitebrowser.yml
@@ -22,7 +22,7 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DFORCE_INTERNAL_QSCINTILLA=TRUE
-      - -Dsqlcipher=1
+      - -Dsqlcipher=0
       - -Wno-dev
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:


### PR DESCRIPTION
sqlcipher build lacks of features available in libsqlite and overrides it which makes it sqlitebrowser unusable for many databases